### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+permissions:
+  contents: read
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/Akhil22061/FranklyAI/security/code-scanning/2](https://github.com/Akhil22061/FranklyAI/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the least privilege required. For this workflow, the steps only need to read repository contents (to check out code and run tests), so the minimal permission is `contents: read`. You can add this block at the root level of the workflow file (above `jobs:`), which will apply to all jobs in the workflow unless overridden. No additional imports or definitions are needed; just add the `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
